### PR TITLE
bug fix: eta on order checkout and confirmation 

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,13 +3,13 @@ class OrdersController < ApplicationController
 
   def show
     @qr = RQRCode::QRCode.new(@order.qr_code, size: 2, level: :h)
-    bar = @event.closest_bar
+    @bar = @event.closest_bar
     @markers =
       [
         { lng: @event.longitude, lat: @event.latitude },
         {
-          lng: bar.longitude, lat: bar.latitude,
-          infoWindow: render_to_string(partial: "events/infowindow", locals: { bar: bar }),
+          lng: @bar.longitude, lat: @bar.latitude,
+          infoWindow: render_to_string(partial: "events/infowindow", locals: { bar: @bar }),
           image_url: helpers.asset_url('logo.png')
         }
       ]

--- a/app/views/orders/_order_checkout.html.erb
+++ b/app/views/orders/_order_checkout.html.erb
@@ -5,7 +5,7 @@
     <div class="map_card card">
       <div class="col-sm-3"  style="border-right: solid 1px grey">
         <p>ETA</p>
-        <p class="eta_btn"><%= @order.eta %>min</p>
+        <p class="eta_btn"><%= @bar.eta %>min</p>
       </div>
       <div class="col-sm-6">
         <p>Location</p>


### PR DESCRIPTION
Bug fix: eta on order checkout and confirmation pages now properly show bar eta instead of current order eta. 

**Note** that right now in the code, every orders are assigned to the first bar of the selected event. That logic will need to be updated at a later date.